### PR TITLE
Annotations

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,6 @@
     "typescript": "^5.2.2",
     "zod": "^3.22.2",
     "zod-validation-error": "^1.5.0",
-    "zodiac-roles-sdk": "^2.2.11"
+    "zodiac-roles-sdk": "^2.2.12"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "swagger-ui-react": "^4.19.0",
     "typescript": "^5.2.2",
     "zod": "^3.22.2",
-    "zod-validation-error": "^1.5.0"
+    "zod-validation-error": "^1.5.0",
+    "zodiac-roles-sdk": "^2.2.10"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,6 @@
     "typescript": "^5.2.2",
     "zod": "^3.22.2",
     "zod-validation-error": "^1.5.0",
-    "zodiac-roles-sdk": "^2.2.10"
+    "zodiac-roles-sdk": "^2.2.11"
   }
 }

--- a/app/pages/api/v1/[mod]/[role]/allow/[protocol]/deposit.ts
+++ b/app/pages/api/v1/[mod]/[role]/allow/[protocol]/deposit.ts
@@ -1,4 +1,4 @@
-import { deposit } from "@/server/actions/deposit"
+import { allowDeposit } from "@/server/actions/deposit"
 import { handle } from "@/server/handle"
 
-export default handle(deposit)
+export default handle(allowDeposit)

--- a/app/pages/api/v1/openapi.json.ts
+++ b/app/pages/api/v1/openapi.json.ts
@@ -2,22 +2,40 @@ import { NextApiRequest, NextApiResponse } from "next"
 import { OpenApiGeneratorV31 } from "@asteasolutions/zod-to-openapi"
 
 import { registry } from "@/server/openapi"
+import { OpenAPIObject } from "openapi3-ts/oas31"
 
 // Respond with our OpenAPI schema
 const handler = (req: NextApiRequest, res: NextApiResponse) => {
   const generator = new OpenApiGeneratorV31(registry.definitions)
-  const document = generator.generateDocument({
-    openapi: "3.0.0",
-    info: {
-      version: "1.0.0",
-      title: "DeFi Kit",
-      description:
-        "Permissions for Zodiac Roles covering interactions with DeFi protocols",
-    },
-    servers: [{ url: "/api/v1" }],
-  })
+  const document = dontExplodedArrayParams(
+    generator.generateDocument({
+      openapi: "3.0.0",
+      info: {
+        version: "1.0.0",
+        title: "DeFi Kit",
+        description:
+          "Permissions for Zodiac Roles covering interactions with DeFi protocols",
+      },
+      servers: [{ url: "/api/v1" }],
+    })
+  )
 
   res.status(200).send(document)
 }
 
 export default handler
+
+function dontExplodedArrayParams(doc: OpenAPIObject): OpenAPIObject {
+  if (!doc.paths) return doc
+
+  for (let [, item] of Object.entries(doc.paths)) {
+    if (item.get?.parameters) {
+      for (let parameter of item.get.parameters) {
+        if ("$ref" in parameter) continue
+        parameter.explode = false
+      }
+    }
+  }
+
+  return doc
+}

--- a/app/pages/api/v1/permissions/[chain]/[protocol]/deposit.ts
+++ b/app/pages/api/v1/permissions/[chain]/[protocol]/deposit.ts
@@ -1,4 +1,4 @@
-import { deposit } from "@/server/actions/deposit"
+import { allowDeposit } from "@/server/actions/deposit"
 import { handle } from "@/server/handle"
 
-export default handle(deposit)
+export default handle(allowDeposit)

--- a/app/pages/api/v1/permissions/[chain]/[protocol]/deposit.ts
+++ b/app/pages/api/v1/permissions/[chain]/[protocol]/deposit.ts
@@ -1,0 +1,4 @@
+import { deposit } from "@/server/actions/deposit"
+import { handle } from "@/server/handle"
+
+export default handle(deposit)

--- a/app/server/actions/borrow.ts
+++ b/app/server/actions/borrow.ts
@@ -1,11 +1,42 @@
-import { NotFoundError, ProtocolActions, decodeBytes32String } from "defi-kit"
+import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
-import { ChainPrefix, sdks } from "../sdk"
-import { docParams, queryBase, transactionsJson } from "../schema"
-import { ActionHandler } from "../handle"
-import { parseQuery } from "../parse"
+import { coercePermission } from "zodiac-roles-sdk"
+import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
+import {
+  docParams,
+  permission,
+  permissionsQueryBase,
+  transactionsJson,
+  transactionsQueryBase,
+} from "../schema"
+import { PermissionsHandler, TransactionsHandler } from "../handle"
 
-export const registerBorrow = (
+export const allowBorrow: TransactionsHandler = async (query) => {
+  const {
+    mod: { address, chain },
+    role,
+    protocol,
+  } = transactionsQueryBase.parse(query)
+  const permissions = queryPermissionSet({
+    action: "borrow",
+    chain,
+    protocol,
+    query,
+  })
+
+  const { apply, exportToSafeTransactionBuilder } = sdks[chain]
+  const calls = await apply(role, permissions, {
+    address,
+    mode: "extend",
+  })
+
+  return exportToSafeTransactionBuilder(calls, {
+    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
+    description: `Allow borrowing the specified \`tokens\` on ${protocol}`,
+  })
+}
+
+export const registerAllowBorrow = (
   registry: OpenAPIRegistry,
   chainPrefix: ChainPrefix,
   protocol: string
@@ -36,39 +67,42 @@ export const registerBorrow = (
   })
 }
 
-export const borrow: ActionHandler = async (query) => {
-  const {
-    mod: { chain, address },
-    role,
-    protocol,
-  } = queryBase.parse(query)
-
-  const sdk = sdks[chain]
-  const { allow, schema } = sdk
-
-  if (!(protocol in schema) || !(protocol in allow)) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const allowBorrow = (allow as any)[protocol].borrow as
-    | ProtocolActions["borrow"]
-    | undefined
-  const borrowParamsSchema = (schema as any)[protocol].borrow as any
-
-  if (!allowBorrow || !borrowParamsSchema) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const permissions = allowBorrow(parseQuery(query, borrowParamsSchema))
-
-  const calls = await sdk.apply(role, permissions, {
-    address,
-    mode: "extend",
+export const borrowPermissions: PermissionsHandler = async (query) => {
+  const permissions = queryPermissionSet({
+    action: "borrow",
+    ...permissionsQueryBase.parse(query),
+    query,
   })
+  return permissions.map(coercePermission)
+}
 
-  return sdk.exportJson(address, calls, {
-    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
-    description: `Allow borrowing the specified \`tokens\` on ${protocol}`,
-    includeAbi: true,
+export const registerBorrowPermissions = (
+  registry: OpenAPIRegistry,
+  chainPrefix: ChainPrefix,
+  protocol: string
+) => {
+  const { schema } = sdks[chainPrefix] as any
+  const querySchema = schema[protocol].borrow
+
+  registry.registerPath({
+    method: "get",
+    path: `/permissions/${chainPrefix}/${protocol}/borrow`,
+    summary: `Allow borrowing the specified tokens`,
+    tags: [protocol],
+    request: {
+      params: docParams,
+      query: querySchema,
+    },
+
+    responses: {
+      200: {
+        description: "Permissions for borrowing the specified tokens",
+        content: {
+          "application/json": {
+            schema: permission.array(),
+          },
+        },
+      },
+    },
   })
 }

--- a/app/server/actions/borrow.ts
+++ b/app/server/actions/borrow.ts
@@ -47,8 +47,8 @@ export const registerAllowBorrow = (
   registry.registerPath({
     method: "get",
     path: `/${chainPrefix}:{mod}/{role}/allow/${protocol}/borrow`,
-    summary: `Allow borrowing the specified tokens`,
-    tags: [protocol],
+    summary: `Transactions for granting permissions to borrow the specified tokens`,
+    tags: [`${protocol} allow`],
     request: {
       params: docParams,
       query: querySchema,
@@ -87,8 +87,8 @@ export const registerBorrowPermissions = (
   registry.registerPath({
     method: "get",
     path: `/permissions/${chainPrefix}/${protocol}/borrow`,
-    summary: `Allow borrowing the specified tokens`,
-    tags: [protocol],
+    summary: `Permissions to borrow the specified tokens`,
+    tags: [`${protocol} permissions`],
     request: {
       params: docParams,
       query: querySchema,

--- a/app/server/actions/delegate.ts
+++ b/app/server/actions/delegate.ts
@@ -1,11 +1,35 @@
-import { NotFoundError, ProtocolActions, decodeBytes32String } from "defi-kit"
+import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
-import { ChainPrefix, sdks } from "../sdk"
-import { docParams, queryBase, transactionsJson } from "../schema"
-import { ActionHandler } from "../handle"
-import { parseQuery } from "../parse"
+import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
+import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
+import { TransactionsHandler } from "../handle"
 
-export const registerDelegate = (
+export const allowDelegate: TransactionsHandler = async (query) => {
+  const {
+    mod: { address, chain },
+    role,
+    protocol,
+  } = transactionsQueryBase.parse(query)
+  const permissions = queryPermissionSet({
+    action: "delegate",
+    chain,
+    protocol,
+    query,
+  })
+
+  const { apply, exportToSafeTransactionBuilder } = sdks[chain]
+  const calls = await apply(role, permissions, {
+    address,
+    mode: "extend",
+  })
+
+  return exportToSafeTransactionBuilder(calls, {
+    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
+    description: `Allow delegation of the ${protocol} \`targets\``,
+  })
+}
+
+export const registerAllowDelegate = (
   registry: OpenAPIRegistry,
   chainPrefix: ChainPrefix,
   protocol: string
@@ -33,42 +57,5 @@ export const registerDelegate = (
         },
       },
     },
-  })
-}
-
-export const delegate: ActionHandler = async (query) => {
-  const {
-    mod: { chain, address },
-    role,
-    protocol,
-  } = queryBase.parse(query)
-
-  const sdk = sdks[chain]
-  const { allow, schema } = sdk
-
-  if (!(protocol in schema) || !(protocol in allow)) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const allowDelegate = (allow as any)[protocol].delegate as
-    | ProtocolActions["delegate"]
-    | undefined
-  const delegateParamsSchema = (schema as any)[protocol].delegate as any
-
-  if (!allowDelegate || !delegateParamsSchema) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const permissions = allowDelegate(parseQuery(query, delegateParamsSchema))
-
-  const calls = await sdk.apply(role, permissions, {
-    address,
-    mode: "extend",
-  })
-
-  return sdk.exportJson(address, calls, {
-    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
-    description: `Allow delegation of the ${protocol} \`targets\``,
-    includeAbi: true,
   })
 }

--- a/app/server/actions/deposit.ts
+++ b/app/server/actions/deposit.ts
@@ -1,11 +1,35 @@
-import { NotFoundError, ProtocolActions, decodeBytes32String } from "defi-kit"
+import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
-import { ChainPrefix, sdks } from "../sdk"
-import { docParams, queryBase, transactionsJson } from "../schema"
-import { ActionHandler } from "../handle"
-import { parseQuery } from "../parse"
+import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
+import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
+import { TransactionsHandler } from "../handle"
 
-export const registerDeposit = (
+export const allowDeposit: TransactionsHandler = async (query) => {
+  const {
+    mod: { address, chain },
+    role,
+    protocol,
+  } = transactionsQueryBase.parse(query)
+  const permissions = queryPermissionSet({
+    action: "deposit",
+    chain,
+    protocol,
+    query,
+  })
+
+  const { apply, exportToSafeTransactionBuilder } = sdks[chain]
+  const calls = await apply(role, permissions, {
+    address,
+    mode: "extend",
+  })
+
+  return exportToSafeTransactionBuilder(calls, {
+    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
+    description: `Allow managing deposits to the \`target\` ${protocol} pool`,
+  })
+}
+
+export const registerAllowDeposit = (
   registry: OpenAPIRegistry,
   chainPrefix: ChainPrefix,
   protocol: string
@@ -33,42 +57,5 @@ export const registerDeposit = (
         },
       },
     },
-  })
-}
-
-export const deposit: ActionHandler = async (query) => {
-  const {
-    mod: { chain, address },
-    role,
-    protocol,
-  } = queryBase.parse(query)
-
-  const sdk = sdks[chain]
-  const { allow, schema } = sdk
-
-  if (!(protocol in schema) || !(protocol in allow)) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const allowDeposit = (allow as any)[protocol].deposit as
-    | ProtocolActions["deposit"]
-    | undefined
-  const depositParams = (schema as any)[protocol].deposit as any
-
-  if (!allowDeposit || !depositParams) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const permissions = allowDeposit(parseQuery(query, depositParams))
-
-  const calls = await sdk.apply(role, permissions, {
-    address,
-    mode: "extend",
-  })
-
-  return sdk.exportJson(address, calls, {
-    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
-    description: `Allow managing deposits to the \`target\` ${protocol} pool`,
-    includeAbi: true,
   })
 }

--- a/app/server/actions/deposit.ts
+++ b/app/server/actions/deposit.ts
@@ -1,8 +1,15 @@
 import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
+import { coercePermission } from "zodiac-roles-sdk"
 import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
-import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
-import { TransactionsHandler } from "../handle"
+import {
+  docParams,
+  permission,
+  permissionsQueryBase,
+  transactionsJson,
+  transactionsQueryBase,
+} from "../schema"
+import { PermissionsHandler, TransactionsHandler } from "../handle"
 
 export const allowDeposit: TransactionsHandler = async (query) => {
   const {
@@ -41,7 +48,7 @@ export const registerAllowDeposit = (
     method: "get",
     path: `/${chainPrefix}:{mod}/{role}/allow/${protocol}/deposit`,
     summary: `Allow managing deposits to the target ${protocol} pools`,
-    tags: [protocol],
+    tags: [`${protocol} allow`],
     request: {
       params: docParams,
       query: querySchema,
@@ -53,6 +60,46 @@ export const registerAllowDeposit = (
         content: {
           "application/json": {
             schema: transactionsJson,
+          },
+        },
+      },
+    },
+  })
+}
+
+export const depositPermissions: PermissionsHandler = async (query) => {
+  const permissions = queryPermissionSet({
+    action: "deposit",
+    ...permissionsQueryBase.parse(query),
+    query,
+  })
+  return permissions.map(coercePermission)
+}
+
+export const registerDepositPermissions = (
+  registry: OpenAPIRegistry,
+  chainPrefix: ChainPrefix,
+  protocol: string
+) => {
+  const { schema } = sdks[chainPrefix] as any
+  const querySchema = schema[protocol].deposit
+
+  registry.registerPath({
+    method: "get",
+    path: `/permissions/${chainPrefix}/${protocol}/deposit`,
+    summary: `Permissions for depositing to the \`target\` ${protocol} pool`,
+    tags: [`${protocol} permissions`],
+    request: {
+      params: docParams,
+      query: querySchema,
+    },
+
+    responses: {
+      200: {
+        description: `Permissions for depositing to the \`target\` ${protocol} pool`,
+        content: {
+          "application/json": {
+            schema: permission.array(),
           },
         },
       },

--- a/app/server/actions/lock.ts
+++ b/app/server/actions/lock.ts
@@ -1,8 +1,15 @@
 import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
+import { coercePermission } from "zodiac-roles-sdk"
 import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
-import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
-import { TransactionsHandler } from "../handle"
+import {
+  docParams,
+  permission,
+  permissionsQueryBase,
+  transactionsJson,
+  transactionsQueryBase,
+} from "../schema"
+import { PermissionsHandler, TransactionsHandler } from "../handle"
 
 export const allowLock: TransactionsHandler = async (query) => {
   const {
@@ -40,8 +47,8 @@ export const registerAllowLock = (
   registry.registerPath({
     method: "get",
     path: `/${chainPrefix}:{mod}/{role}/allow/${protocol}/lock`,
-    summary: `Allow locking to the specified targets`,
-    tags: [protocol],
+    summary: `Allow locking to the specified ${protocol} targets`,
+    tags: [`${protocol} allow`],
     request: {
       params: docParams,
       query: querySchema,
@@ -53,6 +60,46 @@ export const registerAllowLock = (
         content: {
           "application/json": {
             schema: transactionsJson,
+          },
+        },
+      },
+    },
+  })
+}
+
+export const lockPermissions: PermissionsHandler = async (query) => {
+  const permissions = queryPermissionSet({
+    action: "lock",
+    ...permissionsQueryBase.parse(query),
+    query,
+  })
+  return permissions.map(coercePermission)
+}
+
+export const registerLockPermissions = (
+  registry: OpenAPIRegistry,
+  chainPrefix: ChainPrefix,
+  protocol: string
+) => {
+  const { schema } = sdks[chainPrefix] as any
+  const querySchema = schema[protocol].lock
+
+  registry.registerPath({
+    method: "get",
+    path: `/permissions/${chainPrefix}/${protocol}/lock`,
+    summary: `Permissions for locking to the specified ${protocol} \`targets\``,
+    tags: [`${protocol} permissions`],
+    request: {
+      params: docParams,
+      query: querySchema,
+    },
+
+    responses: {
+      200: {
+        description: `Permissions for locking to the ${protocol} targets`,
+        content: {
+          "application/json": {
+            schema: permission.array(),
           },
         },
       },

--- a/app/server/actions/stake.ts
+++ b/app/server/actions/stake.ts
@@ -1,8 +1,15 @@
 import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
+import { coercePermission } from "zodiac-roles-sdk"
 import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
-import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
-import { TransactionsHandler } from "../handle"
+import {
+  docParams,
+  permission,
+  permissionsQueryBase,
+  transactionsJson,
+  transactionsQueryBase,
+} from "../schema"
+import { PermissionsHandler, TransactionsHandler } from "../handle"
 
 export const allowStake: TransactionsHandler = async (query) => {
   const {
@@ -41,7 +48,7 @@ export const registerAllowStake = (
     method: "get",
     path: `/${chainPrefix}:{mod}/{role}/allow/${protocol}/stake`,
     summary: `Allow staking to the specified targets`,
-    tags: [protocol],
+    tags: [`${protocol} allow`],
     request: {
       params: docParams,
       query: querySchema,
@@ -53,6 +60,46 @@ export const registerAllowStake = (
         content: {
           "application/json": {
             schema: transactionsJson,
+          },
+        },
+      },
+    },
+  })
+}
+
+export const stakePermissions: PermissionsHandler = async (query) => {
+  const permissions = queryPermissionSet({
+    action: "stake",
+    ...permissionsQueryBase.parse(query),
+    query,
+  })
+  return permissions.map(coercePermission)
+}
+
+export const registerStakePermissions = (
+  registry: OpenAPIRegistry,
+  chainPrefix: ChainPrefix,
+  protocol: string
+) => {
+  const { schema } = sdks[chainPrefix] as any
+  const querySchema = schema[protocol].stake
+
+  registry.registerPath({
+    method: "get",
+    path: `/permissions/${chainPrefix}/${protocol}/stake`,
+    summary: `Permissions for staking to the specified ${protocol} \`targets\``,
+    tags: [`${protocol} permissions`],
+    request: {
+      params: docParams,
+      query: querySchema,
+    },
+
+    responses: {
+      200: {
+        description: `Permissions for staking to the ${protocol} targets`,
+        content: {
+          "application/json": {
+            schema: permission.array(),
           },
         },
       },

--- a/app/server/actions/stake.ts
+++ b/app/server/actions/stake.ts
@@ -1,11 +1,35 @@
-import { NotFoundError, ProtocolActions, decodeBytes32String } from "defi-kit"
+import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
-import { ChainPrefix, sdks } from "../sdk"
-import { docParams, queryBase, transactionsJson } from "../schema"
-import { ActionHandler } from "../handle"
-import { parseQuery } from "../parse"
+import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
+import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
+import { TransactionsHandler } from "../handle"
 
-export const registerStake = (
+export const allowStake: TransactionsHandler = async (query) => {
+  const {
+    mod: { address, chain },
+    role,
+    protocol,
+  } = transactionsQueryBase.parse(query)
+  const permissions = queryPermissionSet({
+    action: "stake",
+    chain,
+    protocol,
+    query,
+  })
+
+  const { apply, exportToSafeTransactionBuilder } = sdks[chain]
+  const calls = await apply(role, permissions, {
+    address,
+    mode: "extend",
+  })
+
+  return exportToSafeTransactionBuilder(calls, {
+    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
+    description: `Allow staking to the ${protocol} \`targets\``,
+  })
+}
+
+export const registerAllowStake = (
   registry: OpenAPIRegistry,
   chainPrefix: ChainPrefix,
   protocol: string
@@ -33,42 +57,5 @@ export const registerStake = (
         },
       },
     },
-  })
-}
-
-export const stake: ActionHandler = async (query) => {
-  const {
-    mod: { chain, address },
-    role,
-    protocol,
-  } = queryBase.parse(query)
-
-  const sdk = sdks[chain]
-  const { allow, schema } = sdk
-
-  if (!(protocol in schema) || !(protocol in allow)) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const allowStake = (allow as any)[protocol].stake as
-    | ProtocolActions["stake"]
-    | undefined
-  const stakeParamsSchema = (schema as any)[protocol].stake as any
-
-  if (!allowStake || !stakeParamsSchema) {
-    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
-  }
-
-  const permissions = allowStake(parseQuery(query, stakeParamsSchema))
-
-  const calls = await sdk.apply(role, permissions, {
-    address,
-    mode: "extend",
-  })
-
-  return sdk.exportJson(address, calls, {
-    name: `Extend permissions of "${decodeBytes32String(role)}" role`,
-    description: `Allow staking to the ${protocol} \`targets\``,
-    includeAbi: true,
   })
 }

--- a/app/server/actions/swap.ts
+++ b/app/server/actions/swap.ts
@@ -1,8 +1,15 @@
 import { decodeBytes32String } from "defi-kit"
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
+import { coercePermission } from "zodiac-roles-sdk"
 import { ChainPrefix, queryPermissionSet, sdks } from "../sdk"
-import { docParams, transactionsJson, transactionsQueryBase } from "../schema"
-import { TransactionsHandler } from "../handle"
+import {
+  docParams,
+  permission,
+  permissionsQueryBase,
+  transactionsJson,
+  transactionsQueryBase,
+} from "../schema"
+import { PermissionsHandler, TransactionsHandler } from "../handle"
 
 export const allowSwap: TransactionsHandler = async (query) => {
   const {
@@ -11,7 +18,7 @@ export const allowSwap: TransactionsHandler = async (query) => {
     protocol,
   } = transactionsQueryBase.parse(query)
   const permissions = queryPermissionSet({
-    action: "stake",
+    action: "swap",
     chain,
     protocol,
     query,
@@ -41,7 +48,7 @@ export const registerAllowSwap = (
     method: "get",
     path: `/${chainPrefix}:{mod}/{role}/allow/${protocol}/swap`,
     summary: `Allow making swaps on ${protocol}`,
-    tags: [protocol],
+    tags: [`${protocol} allow`],
     request: {
       params: docParams,
       query: querySchema,
@@ -53,6 +60,46 @@ export const registerAllowSwap = (
         content: {
           "application/json": {
             schema: transactionsJson,
+          },
+        },
+      },
+    },
+  })
+}
+
+export const swapPermissions: PermissionsHandler = async (query) => {
+  const permissions = queryPermissionSet({
+    action: "swap",
+    ...permissionsQueryBase.parse(query),
+    query,
+  })
+  return permissions.map(coercePermission)
+}
+
+export const registerSwapPermissions = (
+  registry: OpenAPIRegistry,
+  chainPrefix: ChainPrefix,
+  protocol: string
+) => {
+  const { schema } = sdks[chainPrefix] as any
+  const querySchema = schema[protocol].swap
+
+  registry.registerPath({
+    method: "get",
+    path: `/permissions/${chainPrefix}/${protocol}/swap`,
+    summary: `Permissions for making swaps on ${protocol}`,
+    tags: [`${protocol} permissions`],
+    request: {
+      params: docParams,
+      query: querySchema,
+    },
+
+    responses: {
+      200: {
+        description: `Permissions for making swaps on ${protocol}`,
+        content: {
+          "application/json": {
+            schema: permission.array(),
           },
         },
       },

--- a/app/server/handle.ts
+++ b/app/server/handle.ts
@@ -3,22 +3,26 @@ import { NotFoundError } from "defi-kit"
 import { fromZodError } from "zod-validation-error"
 import { ZodError } from "zod"
 
-import { TransactionsJson } from "./schema"
+import { Permission, ResponseJson, TransactionsJson } from "./schema"
 
-export type ActionHandler = (
+export type PermissionsHandler = (
+  query: NextApiRequest["query"]
+) => Promise<Permission[]>
+
+export type TransactionsHandler = (
   query: NextApiRequest["query"]
 ) => Promise<TransactionsJson>
 
 export const handle =
-  (handler: ActionHandler) =>
+  (handler: TransactionsHandler | PermissionsHandler) =>
   async (
     req: NextApiRequest,
-    res: NextApiResponse<TransactionsJson | ErrorJson>
+    res: NextApiResponse<ResponseJson | ErrorJson>
   ) => {
     console.log(req.query)
     try {
       const result = await handler(req.query)
-      res.status(200).json(result)
+      res.status(200).json(result as any)
     } catch (e) {
       console.error(e)
 

--- a/app/server/openapi.ts
+++ b/app/server/openapi.ts
@@ -15,10 +15,15 @@ import { registerAllowSwap } from "./actions/swap"
 import { registerAllowStake } from "./actions/stake"
 import { registerAllowLock } from "./actions/lock"
 import { registerAllowDelegate } from "./actions/delegate"
+import { permission, condition, transactionsJson } from "./schema"
 
 extendZodWithOpenApi(zod)
 
 export const registry = new OpenAPIRegistry()
+
+registry.register("Condition", condition)
+registry.register("Permission", permission)
+registry.register("TransactionsJson", transactionsJson)
 
 // traverse through the sdk structure and register all API endpoints
 Object.entries(sdks).forEach(([chain, sdk]) => {
@@ -33,23 +38,23 @@ Object.entries(sdks).forEach(([chain, sdk]) => {
           return
         case "deposit":
           registerAllowDeposit(registry, chainPrefix, protocol)
-          registerDepositPermissions(registry, chainPrefix, protocol)
+          // registerDepositPermissions(registry, chainPrefix, protocol)
           return
         case "swap":
           registerAllowSwap(registry, chainPrefix, protocol)
-          registerSwapPermissions(registry, chainPrefix, protocol)
+          // registerSwapPermissions(registry, chainPrefix, protocol)
           return
         case "stake":
           registerAllowStake(registry, chainPrefix, protocol)
-          registerStakePermissions(registry, chainPrefix, protocol)
+          // registerStakePermissions(registry, chainPrefix, protocol)
           return
         case "lock":
           registerAllowLock(registry, chainPrefix, protocol)
-          registerLockPermissions(registry, chainPrefix, protocol)
+          // registerLockPermissions(registry, chainPrefix, protocol)
           return
         case "delegate":
           registerAllowDelegate(registry, chainPrefix, protocol)
-          registerDelegatePermissions(registry, chainPrefix, protocol)
+          // registerDelegatePermissions(registry, chainPrefix, protocol)
           return
         default:
           throw new Error(`Unknown action: ${action}`)

--- a/app/server/openapi.ts
+++ b/app/server/openapi.ts
@@ -10,11 +10,17 @@ import {
   registerAllowBorrow,
   registerBorrowPermissions,
 } from "./actions/borrow"
-import { registerAllowDeposit } from "./actions/deposit"
-import { registerAllowSwap } from "./actions/swap"
-import { registerAllowStake } from "./actions/stake"
-import { registerAllowLock } from "./actions/lock"
-import { registerAllowDelegate } from "./actions/delegate"
+import {
+  registerAllowDeposit,
+  registerDepositPermissions,
+} from "./actions/deposit"
+import { registerAllowSwap, registerSwapPermissions } from "./actions/swap"
+import { registerAllowStake, registerStakePermissions } from "./actions/stake"
+import { registerAllowLock, registerLockPermissions } from "./actions/lock"
+import {
+  registerAllowDelegate,
+  registerDelegatePermissions,
+} from "./actions/delegate"
 import { permission, condition, transactionsJson } from "./schema"
 
 extendZodWithOpenApi(zod)
@@ -38,23 +44,23 @@ Object.entries(sdks).forEach(([chain, sdk]) => {
           return
         case "deposit":
           registerAllowDeposit(registry, chainPrefix, protocol)
-          // registerDepositPermissions(registry, chainPrefix, protocol)
+          registerDepositPermissions(registry, chainPrefix, protocol)
           return
         case "swap":
           registerAllowSwap(registry, chainPrefix, protocol)
-          // registerSwapPermissions(registry, chainPrefix, protocol)
+          registerSwapPermissions(registry, chainPrefix, protocol)
           return
         case "stake":
           registerAllowStake(registry, chainPrefix, protocol)
-          // registerStakePermissions(registry, chainPrefix, protocol)
+          registerStakePermissions(registry, chainPrefix, protocol)
           return
         case "lock":
           registerAllowLock(registry, chainPrefix, protocol)
-          // registerLockPermissions(registry, chainPrefix, protocol)
+          registerLockPermissions(registry, chainPrefix, protocol)
           return
         case "delegate":
           registerAllowDelegate(registry, chainPrefix, protocol)
-          // registerDelegatePermissions(registry, chainPrefix, protocol)
+          registerDelegatePermissions(registry, chainPrefix, protocol)
           return
         default:
           throw new Error(`Unknown action: ${action}`)

--- a/app/server/openapi.ts
+++ b/app/server/openapi.ts
@@ -6,12 +6,15 @@ import {
 } from "@asteasolutions/zod-to-openapi"
 
 import { sdks } from "./sdk"
-import { registerBorrow } from "./actions/borrow"
-import { registerDeposit } from "./actions/deposit"
-import { registerSwap } from "./actions/swap"
-import { registerStake } from "./actions/stake"
-import { registerLock } from "./actions/lock"
-import { registerDelegate } from "./actions/delegate"
+import {
+  registerAllowBorrow,
+  registerBorrowPermissions,
+} from "./actions/borrow"
+import { registerAllowDeposit } from "./actions/deposit"
+import { registerAllowSwap } from "./actions/swap"
+import { registerAllowStake } from "./actions/stake"
+import { registerAllowLock } from "./actions/lock"
+import { registerAllowDelegate } from "./actions/delegate"
 
 extendZodWithOpenApi(zod)
 
@@ -25,22 +28,28 @@ Object.entries(sdks).forEach(([chain, sdk]) => {
     Object.keys(protocolActions).forEach((action) => {
       switch (action) {
         case "borrow":
-          registerBorrow(registry, chainPrefix, protocol)
+          registerAllowBorrow(registry, chainPrefix, protocol)
+          registerBorrowPermissions(registry, chainPrefix, protocol)
           return
         case "deposit":
-          registerDeposit(registry, chainPrefix, protocol)
+          registerAllowDeposit(registry, chainPrefix, protocol)
+          registerDepositPermissions(registry, chainPrefix, protocol)
           return
         case "swap":
-          registerSwap(registry, chainPrefix, protocol)
+          registerAllowSwap(registry, chainPrefix, protocol)
+          registerSwapPermissions(registry, chainPrefix, protocol)
           return
         case "stake":
-          registerStake(registry, chainPrefix, protocol)
+          registerAllowStake(registry, chainPrefix, protocol)
+          registerStakePermissions(registry, chainPrefix, protocol)
           return
         case "lock":
-          registerLock(registry, chainPrefix, protocol)
+          registerAllowLock(registry, chainPrefix, protocol)
+          registerLockPermissions(registry, chainPrefix, protocol)
           return
         case "delegate":
-          registerDelegate(registry, chainPrefix, protocol)
+          registerAllowDelegate(registry, chainPrefix, protocol)
+          registerDelegatePermissions(registry, chainPrefix, protocol)
           return
         default:
           throw new Error(`Unknown action: ${action}`)

--- a/app/server/schema.ts
+++ b/app/server/schema.ts
@@ -84,8 +84,10 @@ export const transactionsJson = z.object({
   transactions: z.array(
     z.object({
       to: z.string(),
-      data: z.string(),
+      data: z.string().optional(),
       value: z.string(),
+      contractMethod: z.any().optional(),
+      contractInputsValues: z.record(z.string()).optional(),
     })
   ),
 })

--- a/app/server/schema.ts
+++ b/app/server/schema.ts
@@ -102,9 +102,31 @@ type Condition = z.infer<typeof baseCondition> & {
   children?: Condition[]
 }
 
-const condition: z.ZodType<Condition> = baseCondition.extend({
-  children: z.lazy(() => condition.array()).optional(),
-})
+export const condition: z.ZodType<Condition> = baseCondition
+  .extend({
+    children: z.lazy(() => condition.array()).optional(),
+  })
+  .openapi({
+    type: "object",
+    properties: {
+      paramType: {
+        type: "number",
+      },
+      operator: {
+        type: "number",
+      },
+      compValue: {
+        type: "string",
+      },
+      children: {
+        type: "array",
+        items: {
+          $ref: "#/components/schemas/Condition", // we're registering the schema as a component in openapi.ts
+        },
+      },
+    },
+    required: ["paramType", "operator"],
+  })
 
 export const permission = z.object({
   targetAddress: z.string(), // we don't use zx.address() here because PermissionSet.targetAddress is typed as string

--- a/app/server/sdk.ts
+++ b/app/server/sdk.ts
@@ -1,5 +1,7 @@
 import * as eth from "defi-kit/eth"
 import * as gor from "defi-kit/gor"
+import { ActionName, Chain, NotFoundError, ProtocolActions } from "defi-kit"
+import { parseQuery } from "./parse"
 
 export const sdks = {
   eth,
@@ -11,3 +13,37 @@ export const sdks = {
 } as const
 
 export type ChainPrefix = keyof typeof sdks
+
+export const queryPermissionSet = ({
+  action,
+  chain,
+  protocol,
+  query,
+}: {
+  action: ActionName
+  chain: Chain
+  protocol: string
+  query: Partial<{
+    [key: string]: string | string[]
+  }>
+}) => {
+  const sdk = sdks[chain]
+  const { allow, schema } = sdk
+
+  if (!(protocol in schema) || !(protocol in allow)) {
+    throw new NotFoundError(`${protocol} is not supported on ${chain}`)
+  }
+
+  const allowAction = (allow as any)[protocol][action] as
+    | ProtocolActions[ActionName]
+    | undefined
+  const paramsSchema = (schema as any)[protocol][action]
+
+  if (!allowAction || !paramsSchema) {
+    throw new NotFoundError(
+      `${protocol} does not implement the ${action} action`
+    )
+  }
+
+  return allowAction(parseQuery(query, paramsSchema))
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -23,6 +23,12 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "server/permissions"
+  ],
   "exclude": ["node_modules"]
 }

--- a/playground/src/getExample.ts
+++ b/playground/src/getExample.ts
@@ -8,7 +8,7 @@ export const getExampleSourceCode = (exampleName: string) => {
 // You can use this for exploring the SDK and composing your role permissions.
 
 import { encodeBytes32String } from 'defi-kit'
-import { allow, apply, exportJson } from 'defi-kit/gor'
+import { allow, apply, exportToSafeTransactionBuilder } from 'defi-kit/gor'
 
 const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
@@ -17,7 +17,7 @@ const ROLES_MOD = '0x74F819Fa1D95B57a15ECDEf9ce5c779C1bD6cc8A'
 
 // Mix and match the permissions you need
 const permissions = [
-  ...allow.cowswap.swap({buy: [DAI, USDC], sell: [DAI, USDC]})
+  allow.cowswap.swap({buy: [DAI, USDC], sell: [DAI, USDC]})
 ]
 
 // Apply the permissions to an existing role.
@@ -30,6 +30,6 @@ const calls = await apply(roleKey, permissions, {
 })
 
 // Log the JSON that can be uploaded to the Safe Transaction Builder app for execution
-console.log(exportJson(ROLES_MOD, calls))
+console.log(exportToSafeTransactionBuilder(calls))
 `
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -47,10 +47,11 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^5.5.0",
+    "@ethersproject/abi": "^5.7.0",
     "ethers": "^5.7.2",
     "ts-jest": "^29.1.1",
     "zod": "^3.22.2",
-    "zodiac-roles-sdk": "^2.2.4"
+    "zodiac-roles-sdk": "^2.2.9"
   },
   "devDependencies": {
     "@dethcrypto/eth-sdk": "^0.3.4",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defi-kit",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Permissions for Zodiac Roles covering interactions with DeFi protocols",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -51,7 +51,7 @@
     "ethers": "^5.7.2",
     "ts-jest": "^29.1.1",
     "zod": "^3.22.2",
-    "zodiac-roles-sdk": "^2.2.9"
+    "zodiac-roles-sdk": "^2.2.10"
   },
   "devDependencies": {
     "@dethcrypto/eth-sdk": "^0.3.4",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defi-kit",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Permissions for Zodiac Roles covering interactions with DeFi protocols",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defi-kit",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Permissions for Zodiac Roles covering interactions with DeFi protocols",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -51,7 +51,7 @@
     "ethers": "^5.7.2",
     "ts-jest": "^29.1.1",
     "zod": "^3.22.2",
-    "zodiac-roles-sdk": "^2.2.10"
+    "zodiac-roles-sdk": "^2.2.11"
   },
   "devDependencies": {
     "@dethcrypto/eth-sdk": "^0.3.4",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -51,7 +51,7 @@
     "ethers": "^5.7.2",
     "ts-jest": "^29.1.1",
     "zod": "^3.22.2",
-    "zodiac-roles-sdk": "^2.2.11"
+    "zodiac-roles-sdk": "^2.2.14"
   },
   "devDependencies": {
     "@dethcrypto/eth-sdk": "^0.3.4",

--- a/sdk/src/apply.ts
+++ b/sdk/src/apply.ts
@@ -35,7 +35,7 @@ export const createApply = (chainId: ChainId) => {
   ) {
     const { targets, annotations } = processPermissions(permissions)
     checkIntegrity(targets)
-
+    console.log({ targets, annotations })
     let rolesModCalls: `0x${string}`[] = []
     let posterCalls: `0x${string}`[] = []
     try {
@@ -57,7 +57,7 @@ export const createApply = (chainId: ChainId) => {
       throw e
     }
 
-    const value = 0n as const
+    const value = "0" as const
     return [
       ...rolesModCalls.map((data) => ({
         to: options.address,

--- a/sdk/src/apply.ts
+++ b/sdk/src/apply.ts
@@ -6,6 +6,8 @@ import {
   applyAnnotations,
   ChainId,
   PermissionSet,
+  Target,
+  Annotation,
 } from "zodiac-roles-sdk"
 import { NotFoundError } from "./errors"
 
@@ -19,6 +21,9 @@ type Options = {
    */
   mode: "replace" | "extend" | "remove"
   log?: boolean | ((message: string) => void)
+
+  currentTargets?: Target[]
+  currentAnnotations?: Annotation[]
 }
 
 export const createApply = (chainId: ChainId) => {

--- a/sdk/src/apply.ts
+++ b/sdk/src/apply.ts
@@ -1,23 +1,17 @@
 import {
   Permission,
-  processPermissions as processPermissionsBase,
+  processPermissions,
   checkIntegrity,
   applyTargets,
-  Target,
+  applyAnnotations,
   ChainId,
+  PermissionSet,
 } from "zodiac-roles-sdk"
 import { NotFoundError } from "./errors"
 
-type Options = (
-  | {
-      /** Address of the Roles mod */
-      address: string
-    }
-  | {
-      /** The targets that are currently set on the role */
-      currentTargets: Target[]
-    }
-) & {
+type Options = {
+  address: `0x${string}`
+
   /**  The mode to use for updating the permissions of the role:
    *  - "replace": The role will have only the passed permissions, meaning that all other currently configured permissions will be revoked from the role
    *  - "extend": The role will keep its current permissions and will additionally be granted the passed permissions
@@ -30,23 +24,30 @@ type Options = (
 export const createApply = (chainId: ChainId) => {
   /**
    * Applies the passed permissions to the role.
-   * @param roleKey The role key of the role to apply the permissions to
+   * @param address The address of the Roles mod that shall be configured
+   * @param roleKey The bytes32 role key of the role to apply the permissions to
    * @param permissions The permissions to apply
    */
   return async function apply(
-    roleKey: string,
-    permissions: Permission[],
+    roleKey: `0x${string}`,
+    permissions: (Permission | PermissionSet)[],
     options: Options
   ) {
-    const targets = processPermissionsBase(permissions)
+    const { targets, annotations } = processPermissions(permissions)
     checkIntegrity(targets)
 
+    let rolesModCalls: string[] = []
+    let posterCalls: string[] = []
     try {
-      return await applyTargets(
-        roleKey,
-        targets,
-        "address" in options ? { ...options, chainId } : options
-      )
+      rolesModCalls = await applyTargets(roleKey, targets, {
+        ...options,
+        chainId,
+      })
+
+      posterCalls = await applyAnnotations(roleKey, annotations, {
+        ...options,
+        chainId,
+      })
     } catch (e) {
       // make role not found error to NotFoundError so the API will respond with 404
       if (e instanceof Error && e.message.indexOf("not found") !== -1) {
@@ -55,5 +56,23 @@ export const createApply = (chainId: ChainId) => {
 
       throw e
     }
+
+    const value = 0n as const
+    return [
+      ...rolesModCalls.map((data) => ({
+        to: options.address,
+        data,
+        value,
+      })),
+      ...posterCalls.map((data) => ({
+        to: POSTER_ADDRESS,
+        data,
+        value,
+      })),
+    ]
   }
 }
+
+// EIP-3722 Poster contract
+export const POSTER_ADDRESS =
+  "0x000000000000cd17345801aa8147b8D3950260FF" as const

--- a/sdk/src/apply.ts
+++ b/sdk/src/apply.ts
@@ -36,8 +36,8 @@ export const createApply = (chainId: ChainId) => {
     const { targets, annotations } = processPermissions(permissions)
     checkIntegrity(targets)
 
-    let rolesModCalls: string[] = []
-    let posterCalls: string[] = []
+    let rolesModCalls: `0x${string}`[] = []
+    let posterCalls: `0x${string}`[] = []
     try {
       rolesModCalls = await applyTargets(roleKey, targets, {
         ...options,

--- a/sdk/src/encode.ts
+++ b/sdk/src/encode.ts
@@ -1,4 +1,9 @@
 import { formatBytes32String, parseBytes32String } from "ethers/lib/utils"
 
-export const encodeBytes32String = formatBytes32String
-export const decodeBytes32String = parseBytes32String
+export const encodeBytes32String = formatBytes32String as (
+  text: string
+) => `0x${string}`
+
+export const decodeBytes32String = parseBytes32String as (
+  bytes: `0x${string}`
+) => string

--- a/sdk/src/eth.ts
+++ b/sdk/src/eth.ts
@@ -2,9 +2,10 @@ import { eth as allow } from "./protocols"
 import { eth as schema } from "./protocols/schema"
 
 import { createApply } from "./apply"
-import { createExportJson } from "./json"
+import { createExportToSafeTransactionBuilder } from "./export"
 
 export { allow, schema }
 
 export const apply = createApply(1)
-export const exportJson = createExportJson(1)
+export const exportToSafeTransactionBuilder =
+  createExportToSafeTransactionBuilder(1)

--- a/sdk/src/export.ts
+++ b/sdk/src/export.ts
@@ -1,31 +1,26 @@
 import { Interface, Result } from "ethers/lib/utils"
-import { ChainId, rolesAbi } from "zodiac-roles-sdk"
+import { JsonFragment } from "@ethersproject/abi"
+import { ChainId, posterAbi, rolesAbi } from "zodiac-roles-sdk"
+import { POSTER_ADDRESS } from "./apply"
 
-export const createExportJson = (chainId: ChainId) => {
+export const createExportToSafeTransactionBuilder = (chainId: ChainId) => {
   /**
    * Exports calls as a JSON object that can be imported into the Safe Transaction Builder app.
-   * @param address The address of the Roles mod that shall be configured
-   * @param calls The call data to the Roles mod
+   * @param transactions The transactions to export
    * @param meta Meta info to set on the JSON file
    * @returns The Safe Transaction Builder compatible JSON object
    */
-  return function exportJson(
-    address: `0x${string}`,
-    calls: string[],
+  return function exportToSafeTransactionBuilder(
+    transactions: {
+      to: `0x${string}`
+      data: `0x${string}`
+      value: bigint
+    }[],
     meta?: {
       name?: string
       description?: string
-      /** Set to true to include ABI information. This allows the Safe Transaction Builder to show the decoded call data. */
-      includeAbi?: boolean
     }
   ) {
-    const transactions = calls.map((data) => ({
-      to: address,
-      value: "0",
-      data,
-      ...(meta?.includeAbi ? getAbiInfo(data) : {}),
-    }))
-
     return {
       version: "1.0",
       chainId: chainId.toString(10),
@@ -35,22 +30,32 @@ export const createExportJson = (chainId: ChainId) => {
         description: meta?.description || "",
         txBuilderVersion: "1.16.2",
       },
-      transactions,
+      transactions: transactions.map((tx) => ({
+        ...tx,
+        value: tx.value.toString(10),
+        ...getAbiInfo(tx),
+      })),
     } as const
   }
 }
 
-const rolesInterface = new Interface(rolesAbi)
+const getAbiInfo = (transaction: {
+  to: `0x${string}`
+  data: `0x${string}`
+  value: bigint
+}) => {
+  const abi: readonly JsonFragment[] =
+    transaction.to === POSTER_ADDRESS ? posterAbi : rolesAbi
+  const iface = new Interface(abi)
 
-const getAbiInfo = (data: string) => {
-  const selector = data.slice(0, 10)
-  const functionFragment = rolesInterface.getFunction(selector)
+  const selector = transaction.data.slice(0, 10)
+  const functionFragment = iface.getFunction(selector)
 
   if (!functionFragment) {
-    throw new Error(`Could not find a Roles function with selector ${selector}`)
+    throw new Error(`Could not find a function with selector ${selector}`)
   }
 
-  const contractMethod = rolesAbi.find(
+  const contractMethod = abi.find(
     (fragment) =>
       fragment.type === "function" && fragment.name === functionFragment.name
   )
@@ -61,7 +66,7 @@ const getAbiInfo = (data: string) => {
   }
 
   const contractInputsValues = asObject(
-    rolesInterface.decodeFunctionData(functionFragment, data)
+    iface.decodeFunctionData(functionFragment, transaction.data)
   )
 
   return {

--- a/sdk/src/export.ts
+++ b/sdk/src/export.ts
@@ -14,7 +14,7 @@ export const createExportToSafeTransactionBuilder = (chainId: ChainId) => {
     transactions: {
       to: `0x${string}`
       data: `0x${string}`
-      value: bigint
+      value: "0"
     }[],
     meta?: {
       name?: string
@@ -30,19 +30,15 @@ export const createExportToSafeTransactionBuilder = (chainId: ChainId) => {
         description: meta?.description || "",
         txBuilderVersion: "1.16.2",
       },
-      transactions: transactions.map((tx) => ({
-        ...tx,
-        value: tx.value.toString(10),
-        ...getAbiInfo(tx),
-      })),
+      transactions: transactions.map(decode),
     } as const
   }
 }
 
-const getAbiInfo = (transaction: {
+const decode = (transaction: {
   to: `0x${string}`
   data: `0x${string}`
-  value: bigint
+  value: "0"
 }) => {
   const abi: readonly JsonFragment[] =
     transaction.to === POSTER_ADDRESS ? posterAbi : rolesAbi
@@ -70,6 +66,8 @@ const getAbiInfo = (transaction: {
   )
 
   return {
+    to: transaction.to,
+    value: transaction.value,
     contractMethod,
     contractInputsValues,
   }
@@ -78,8 +76,10 @@ const getAbiInfo = (transaction: {
 const asObject = (result: Result) => {
   const object: Record<string, any> = {}
   for (const key of Object.keys(result)) {
-    if (isNaN(Number(key))) continue // skip numeric keys (array indices)
-    object[key] = result[key]
+    // skip numeric keys (array indices)
+    if (isNaN(Number(key))) {
+      object[key] = result[key]
+    }
   }
   return object
 }

--- a/sdk/src/gor.ts
+++ b/sdk/src/gor.ts
@@ -2,9 +2,10 @@ import { gor as allow } from "./protocols"
 import { gor as schema } from "./protocols/schema"
 
 import { createApply } from "./apply"
-import { createExportJson } from "./json"
+import { createExportToSafeTransactionBuilder } from "./export"
 
 export { allow, schema }
 
 export const apply = createApply(5)
-export const exportJson = createExportJson(5)
+export const exportToSafeTransactionBuilder =
+  createExportToSafeTransactionBuilder(5)

--- a/sdk/src/protocols/aave/v3/index.ts
+++ b/sdk/src/protocols/aave/v3/index.ts
@@ -2,8 +2,7 @@ import { NotFoundError } from "../../../errors"
 import tokens from "./_info"
 import { Token, DelegateToken } from "./types"
 import { depositEther, depositToken, borrowEther, borrowToken } from "./actions"
-import { findDelegateToken } from "../v2/index"
-import { stake, governance } from "../v2/actions"
+import { stake, delegate } from "../v2/actions"
 
 const findToken = (symbolOrAddress: string): Token => {
   const nameOrAddressLower = symbolOrAddress.toLowerCase()
@@ -43,7 +42,7 @@ export const eth = {
     return stake()
   },
 
-  // governance: ({
+  // delegate: ({
   //   targets,
   //   delegatee,
   // }: {
@@ -51,7 +50,7 @@ export const eth = {
   //   delegatee: string
   // }) => {
   //   return targets.flatMap((target) =>
-  //     governance(findDelegateToken(target), delegatee)
+  //     delegate(findDelegateToken(target), delegatee)
   //   )
   // },
 }

--- a/sdk/src/protocols/annotate.ts
+++ b/sdk/src/protocols/annotate.ts
@@ -1,0 +1,41 @@
+import { ProtocolActions, ActionFunction } from "../types"
+
+const annotate = <F extends ActionFunction>(
+  actionFunction: F,
+  path: string[]
+): F => {
+  const annotated = (params: any) => {
+    const result = actionFunction(params)
+
+    const queryString = new URLSearchParams(params).toString()
+    const joinedPath = path.join("/")
+    Object.assign(result, {
+      annotation: {
+        uri: `https://kit.karpatkey.com/permissions/${joinedPath}?${queryString}`,
+        schema: "https://kit.karpatkey.com/api/v1/openapi.json",
+      },
+    })
+
+    return result
+  }
+
+  return annotated as F
+}
+
+export const annotateAll = <A extends Record<string, ProtocolActions>>(
+  actions: A,
+  chainPrefix: string
+): A => {
+  const annotated: any = {}
+  for (const [protocolKey, protocolActions] of Object.entries(actions)) {
+    annotated[protocolKey] = {}
+    for (const [actionKey, action] of Object.entries(protocolActions)) {
+      annotated[protocolKey][actionKey] = annotate(action, [
+        chainPrefix,
+        protocolKey,
+        actionKey,
+      ])
+    }
+  }
+  return annotated
+}

--- a/sdk/src/protocols/annotations.test.ts
+++ b/sdk/src/protocols/annotations.test.ts
@@ -1,0 +1,17 @@
+import { gor } from "."
+
+describe("annotations", () => {
+  it("should annotate all action functions", () => {
+    const DAI = "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+    const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    const permissionSet = gor.cowswap.swap({
+      buy: [DAI, USDC],
+      sell: [DAI, USDC],
+    })
+
+    expect(permissionSet).toHaveProperty("annotation", {
+      uri: "https://kit.karpatkey.com/permissions/gor/cowswap/swap?buy=0x6B175474E89094C44Da98b954EedeAC495271d0F%2C0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&sell=0x6B175474E89094C44Da98b954EedeAC495271d0F%2C0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      schema: "https://kit.karpatkey.com/api/v1/openapi.json",
+    })
+  })
+})

--- a/sdk/src/protocols/annotations.test.ts
+++ b/sdk/src/protocols/annotations.test.ts
@@ -8,7 +8,6 @@ describe("annotations", () => {
       buy: [DAI, USDC],
       sell: [DAI, USDC],
     })
-
     expect(permissionSet).toHaveProperty("annotation", {
       uri: "https://kit.karpatkey.com/permissions/gor/cowswap/swap?buy=0x6B175474E89094C44Da98b954EedeAC495271d0F%2C0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&sell=0x6B175474E89094C44Da98b954EedeAC495271d0F%2C0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       schema: "https://kit.karpatkey.com/api/v1/openapi.json",

--- a/sdk/src/protocols/compound/v2/actions.ts
+++ b/sdk/src/protocols/compound/v2/actions.ts
@@ -1,11 +1,10 @@
 import { MintPaused } from "../../../errors"
 import { allow } from "zodiac-roles-sdk/kit"
-import { c } from "zodiac-roles-sdk"
+import { c, Permission } from "zodiac-roles-sdk"
 import { Token, cToken } from "./types"
 import { allowErc20Approve } from "../../../erc20"
-import { PresetFunction } from "zodiac-roles-sdk/build/cjs/sdk/src/presets/types"
 
-// const _mint = (ctoken: cToken): PresetFunction => {
+// const _mint = (ctoken: cToken): Permission => {
 //   return {
 //     targetAddress: ctoken,
 //     signature: "mint(uint256)",
@@ -13,7 +12,7 @@ import { PresetFunction } from "zodiac-roles-sdk/build/cjs/sdk/src/presets/types
 //   }
 // }
 
-const _mint = (ctoken: cToken): PresetFunction => {
+const _mint = (ctoken: cToken): Permission => {
   return {
     ...allow.mainnet.compoundV2.cToken.mint(undefined, { send: true }),
     targetAddress: ctoken,
@@ -21,7 +20,7 @@ const _mint = (ctoken: cToken): PresetFunction => {
 }
 
 // it is called when MAX underlying amount is withdrawn
-const _redeem = (ctoken: cToken): PresetFunction => {
+const _redeem = (ctoken: cToken): Permission => {
   return {
     ...allow.mainnet.compoundV2.cToken.redeem(),
     targetAddress: ctoken,
@@ -29,21 +28,21 @@ const _redeem = (ctoken: cToken): PresetFunction => {
 }
 
 // it is called when MAX underlying amount is NOT withdrawn
-const _redeemUnderlying = (ctoken: cToken): PresetFunction => {
+const _redeemUnderlying = (ctoken: cToken): Permission => {
   return {
     ...allow.mainnet.compoundV2.cToken.redeemUnderlying(),
     targetAddress: ctoken,
   }
 }
 
-const _borrow = (ctoken: cToken): PresetFunction => {
+const _borrow = (ctoken: cToken): Permission => {
   return {
     ...allow.mainnet.compoundV2.cToken.borrow(),
     targetAddress: ctoken,
   }
 }
 
-const _repay = (ctoken: cToken): PresetFunction => {
+const _repay = (ctoken: cToken): Permission => {
   return {
     ...allow.mainnet.compoundV2.cToken.repayBorrow(),
     targetAddress: ctoken,

--- a/sdk/src/protocols/index.ts
+++ b/sdk/src/protocols/index.ts
@@ -1,4 +1,3 @@
-import { ProtocolActions } from "../types"
 import * as aave_v2 from "./aave/v2"
 import * as aave_v3 from "./aave/v3"
 import * as aura from "./aura"
@@ -11,21 +10,29 @@ import * as curve from "./curve"
 import * as lido from "./lido"
 import * as spark from "./spark"
 
-// group all protocols actions by chain
+import { annotateAll } from "./annotate"
 
-export const eth = {
-  aave_v2: aave_v2.eth,
-  aave_v3: aave_v3.eth,
-  aura: aura.eth,
-  balancer: balancer.eth,
-  compound_v2: compound_v2.eth,
-  compound_v3: compound_v3.eth,
-  convex: convex.eth,
-  curve: curve.eth,
-  lido: lido.eth,
-  spark: spark.eth,
-} satisfies Record<string, ProtocolActions>
+// group all protocols actions by chain and wrap the functions to the resulting permissions sets are annotated
 
-export const gor = {
-  cowswap: cowswap.gor,
-} satisfies Record<string, ProtocolActions>
+export const eth = annotateAll(
+  {
+    aave_v2: aave_v2.eth,
+    aave_v3: aave_v3.eth,
+    aura: aura.eth,
+    balancer: balancer.eth,
+    compound_v2: compound_v2.eth,
+    compound_v3: compound_v3.eth,
+    convex: convex.eth,
+    curve: curve.eth,
+    lido: lido.eth,
+    spark: spark.eth,
+  },
+  "eth"
+)
+
+export const gor = annotateAll(
+  {
+    cowswap: cowswap.gor,
+  },
+  "gor"
+)

--- a/sdk/src/protocols/lido/index.ts
+++ b/sdk/src/protocols/lido/index.ts
@@ -1,42 +1,54 @@
-import { c } from "zodiac-roles-sdk"
+import { PermissionSet, c } from "zodiac-roles-sdk"
 import { allow } from "zodiac-roles-sdk/kit"
 import { allowErc20Approve } from "../../erc20"
 import { contracts } from "../../../eth-sdk/config"
 
 export const eth = {
-  deposit: () => [
-    ...allowErc20Approve(
-      [contracts.mainnet.lido.steth],
-      [contracts.mainnet.lido.wsteth]
-    ),
-    ...allowErc20Approve(
-      [contracts.mainnet.lido.steth, contracts.mainnet.lido.wsteth],
-      [contracts.mainnet.lido.unsteth]
-    ),
-    allow.mainnet.lido.wsteth.wrap(),
-    allow.mainnet.lido.wsteth.unwrap(),
-    allow.mainnet.lido.steth.submit(undefined, { send: true }),
-    // Request stETH Withdrawal - Locks your stETH in the queue. In exchange you receive an NFT, that represents your position
-    // in the queue
-    allow.mainnet.lido.unsteth.requestWithdrawals(undefined, c.avatar),
-    // When the unstETH has no allowance over the owner's stETH
-    allow.mainnet.lido.unsteth.requestWithdrawalsWithPermit(
-      undefined,
-      c.avatar
-    ),
+  deposit: (): PermissionSet =>
+    Object.assign(
+      [
+        ...allowErc20Approve(
+          [contracts.mainnet.lido.steth],
+          [contracts.mainnet.lido.wsteth]
+        ),
+        ...allowErc20Approve(
+          [contracts.mainnet.lido.steth, contracts.mainnet.lido.wsteth],
+          [contracts.mainnet.lido.unsteth]
+        ),
+        allow.mainnet.lido.wsteth.wrap(),
+        allow.mainnet.lido.wsteth.unwrap(),
+        allow.mainnet.lido.steth.submit(undefined, { send: true }),
+        // Request stETH Withdrawal - Locks your stETH in the queue. In exchange you receive an NFT, that represents your position
+        // in the queue
+        allow.mainnet.lido.unsteth.requestWithdrawals(undefined, c.avatar),
+        // When the unstETH has no allowance over the owner's stETH
+        allow.mainnet.lido.unsteth.requestWithdrawalsWithPermit(
+          undefined,
+          c.avatar
+        ),
 
-    // Request wstETH Withdrawal - Transfers the wstETH to the unstETH to be burned in exchange for stETH. Then it locks your stETH
-    // in the queue. In exchange you receive an NFT, that represents your position in the queue
-    allow.mainnet.lido.unsteth.requestWithdrawalsWstETH(undefined, c.avatar),
-    // When the unstETH has no allowance over the owner's wstETH
-    allow.mainnet.lido.unsteth.requestWithdrawalsWstETHWithPermit(
-      undefined,
-      c.avatar
-    ),
+        // Request wstETH Withdrawal - Transfers the wstETH to the unstETH to be burned in exchange for stETH. Then it locks your stETH
+        // in the queue. In exchange you receive an NFT, that represents your position in the queue
+        allow.mainnet.lido.unsteth.requestWithdrawalsWstETH(
+          undefined,
+          c.avatar
+        ),
+        // When the unstETH has no allowance over the owner's wstETH
+        allow.mainnet.lido.unsteth.requestWithdrawalsWstETHWithPermit(
+          undefined,
+          c.avatar
+        ),
 
-    // Claim ETH - Once the request is finalized by the oracle report and becomes claimable,
-    // this function claims your ether and burns the NFT
-    allow.mainnet.lido.unsteth.claimWithdrawal(),
-    allow.mainnet.lido.unsteth.claimWithdrawals(),
-  ],
+        // Claim ETH - Once the request is finalized by the oracle report and becomes claimable,
+        // this function claims your ether and burns the NFT
+        allow.mainnet.lido.unsteth.claimWithdrawal(),
+        allow.mainnet.lido.unsteth.claimWithdrawals(),
+      ],
+      {
+        annotation: {
+          uri: "https://kit.karpatkey.com/permissions/eth/lido/deposit",
+          schema: "https://kit.karpatkey.com/api/v1/openapi.json",
+        },
+      }
+    ),
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,5 +1,5 @@
 import { SomeZodObject } from "zod"
-import { Permission } from "zodiac-roles-sdk"
+import { PermissionSet } from "zodiac-roles-sdk"
 
 export enum Chain {
   eth = "eth",
@@ -52,22 +52,23 @@ type SwapOptions =
 
 // These types define the common interface for actions across all protocols
 export type ProtocolActions = {
-  deposit?: (options: DepositOptions) => Permission[]
+  deposit?: (options: DepositOptions) => PermissionSet
 
-  borrow?: (options: BorrowOptions) => Permission[]
+  borrow?: (options: BorrowOptions) => PermissionSet
 
-  stake?: (options: StakeOptions) => Permission[]
+  stake?: (options: StakeOptions) => PermissionSet
 
-  claim?: (options: ClaimOptions) => Permission[]
+  claim?: (options: ClaimOptions) => PermissionSet
 
-  swap?: (options: SwapOptions) => Permission[]
+  swap?: (options: SwapOptions) => PermissionSet
 
-  lock?: (options: LockOptions) => Permission[]
+  lock?: (options: LockOptions) => PermissionSet
 
-  delegate?: (options: DelegateOptions) => Permission[]
+  delegate?: (options: DelegateOptions) => PermissionSet
 }
 
 export type ActionName = keyof ProtocolActions
+export type ActionFunction = NonNullable<ProtocolActions[ActionName]>
 
 // For registering protocols in the REST API we need zod schemas for the specific parameters of each action
 export type ProtocolSchemas = { [key in ActionName]?: SomeZodObject }

--- a/sdk/src/zx.ts
+++ b/sdk/src/zx.ts
@@ -6,8 +6,6 @@ import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi"
 
 extendZodWithOpenApi(z)
 
-const ADDRESS = /^0x[0-9a-fA-F]{40}$/
-
 export const zx = {
   address: () =>
     z.string().transform((val, ctx) => {

--- a/sdk/test/helpers.ts
+++ b/sdk/test/helpers.ts
@@ -15,8 +15,7 @@ export const testRoleKey = encodeBytes32String("TEST-ROLE")
 export const applyPermissions = async (permissions: Permission[]) => {
   const apply = createApply(1) // chainId here won't matter since we pass currentTargets
   const calls = await apply(testRoleKey, permissions, {
-    address: rolesMod.address,
-    currentTargets: [],
+    address: rolesMod.address as `0x${string}`,
     mode: "replace",
     log: console.debug,
   })
@@ -26,8 +25,7 @@ export const applyPermissions = async (permissions: Permission[]) => {
   await Promise.all(
     calls.map((call) =>
       owner.sendTransaction({
-        to: rolesMod.address,
-        data: call,
+        ...call,
         nonce: nonce++,
       })
     )

--- a/sdk/test/helpers.ts
+++ b/sdk/test/helpers.ts
@@ -13,11 +13,13 @@ export const rolesMod = Roles__factory.connect(ROLES_ADDRESS, owner)
 export const testRoleKey = encodeBytes32String("TEST-ROLE")
 
 export const applyPermissions = async (permissions: Permission[]) => {
-  const apply = createApply(1) // chainId here won't matter since we pass currentTargets
+  const apply = createApply(1) // chainId here won't matter (since we pass currentTargets and currentAnnotations no subgraph queries will be made)
   const calls = await apply(testRoleKey, permissions, {
     address: rolesMod.address as `0x${string}`,
     mode: "replace",
     log: console.debug,
+    currentTargets: [],
+    currentAnnotations: [],
   })
 
   console.log(`Applying permissions with ${calls.length} calls`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4655,6 +4655,7 @@ __metadata:
     typescript: ^5.2.2
     zod: ^3.22.2
     zod-validation-error: ^1.5.0
+    zodiac-roles-sdk: ^2.2.10
   languageName: unknown
   linkType: soft
 
@@ -4690,7 +4691,7 @@ __metadata:
     typescript: ^5.2.2
     wait-on: ^7.0.1
     zod: ^3.22.2
-    zodiac-roles-sdk: ^2.2.9
+    zodiac-roles-sdk: ^2.2.10
   languageName: unknown
   linkType: soft
 
@@ -13132,9 +13133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zodiac-roles-sdk@npm:^2.2.9":
-  version: 2.2.9
-  resolution: "zodiac-roles-sdk@npm:2.2.9"
+"zodiac-roles-sdk@npm:^2.2.10":
+  version: 2.2.10
+  resolution: "zodiac-roles-sdk@npm:2.2.10"
   dependencies:
     ethers: ^5.4.7
     type-fest: ^3.7.1
@@ -13144,7 +13145,7 @@ __metadata:
   peerDependenciesMeta:
     "@dethcrypto/eth-sdk-client":
       optional: true
-  checksum: c3a25712e954beb06a5848c0b698ca7c713a42c71dd49ebb9fb6285f8006ad50cf88e28967640a47ec0a937bb6be4fdc5552941a8310e4a4d66d721af6886973
+  checksum: 5b03bba2e5f9dde2044fd2fba920bda58fa3550c85dc4f69a9a9e796ac8d7d7e3583c4ad1f8ae449e602614870bc313590ecfdb87eb24eae577db0f573aba3e2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4655,7 +4655,7 @@ __metadata:
     typescript: ^5.2.2
     zod: ^3.22.2
     zod-validation-error: ^1.5.0
-    zodiac-roles-sdk: ^2.2.11
+    zodiac-roles-sdk: ^2.2.12
   languageName: unknown
   linkType: soft
 
@@ -4691,7 +4691,7 @@ __metadata:
     typescript: ^5.2.2
     wait-on: ^7.0.1
     zod: ^3.22.2
-    zodiac-roles-sdk: ^2.2.11
+    zodiac-roles-sdk: ^2.2.14
   languageName: unknown
   linkType: soft
 
@@ -13133,9 +13133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zodiac-roles-sdk@npm:^2.2.11":
-  version: 2.2.11
-  resolution: "zodiac-roles-sdk@npm:2.2.11"
+"zodiac-roles-sdk@npm:^2.2.12":
+  version: 2.2.12
+  resolution: "zodiac-roles-sdk@npm:2.2.12"
   dependencies:
     ethers: ^5.4.7
     type-fest: ^3.7.1
@@ -13145,7 +13145,23 @@ __metadata:
   peerDependenciesMeta:
     "@dethcrypto/eth-sdk-client":
       optional: true
-  checksum: 4320c96a131c071ed38be64a43115a2ee0ce7ca028cd1861220fa11013f3c74e5e250405a6a108b338401335670b07ecdabcd0bcb93412278e43cb90c76c4a0f
+  checksum: 9477a4a8d8e73645d8bad13ff813a5cc832154a481d474bc07cddeb60d37d1069a091ae0ff46e2208e9026600b3d77e307298db5a5183e361672bd0ed9945950
+  languageName: node
+  linkType: hard
+
+"zodiac-roles-sdk@npm:^2.2.14":
+  version: 2.2.14
+  resolution: "zodiac-roles-sdk@npm:2.2.14"
+  dependencies:
+    ethers: ^5.4.7
+    type-fest: ^3.7.1
+    zod: ^3.22.1
+  peerDependencies:
+    "@dethcrypto/eth-sdk-client": ^0.1.6
+  peerDependenciesMeta:
+    "@dethcrypto/eth-sdk-client":
+      optional: true
+  checksum: 47ea70e7ace7fcd5d83b54db9ad63ca4b46844aa5d9cf516d8f205b9f91a77c374256e09200bf6175c12a88c130f767c983226b66b6da191918aff66a2ed04d6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4655,7 +4655,7 @@ __metadata:
     typescript: ^5.2.2
     zod: ^3.22.2
     zod-validation-error: ^1.5.0
-    zodiac-roles-sdk: ^2.2.10
+    zodiac-roles-sdk: ^2.2.11
   languageName: unknown
   linkType: soft
 
@@ -4691,7 +4691,7 @@ __metadata:
     typescript: ^5.2.2
     wait-on: ^7.0.1
     zod: ^3.22.2
-    zodiac-roles-sdk: ^2.2.10
+    zodiac-roles-sdk: ^2.2.11
   languageName: unknown
   linkType: soft
 
@@ -13133,9 +13133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zodiac-roles-sdk@npm:^2.2.10":
-  version: 2.2.10
-  resolution: "zodiac-roles-sdk@npm:2.2.10"
+"zodiac-roles-sdk@npm:^2.2.11":
+  version: 2.2.11
+  resolution: "zodiac-roles-sdk@npm:2.2.11"
   dependencies:
     ethers: ^5.4.7
     type-fest: ^3.7.1
@@ -13145,7 +13145,7 @@ __metadata:
   peerDependenciesMeta:
     "@dethcrypto/eth-sdk-client":
       optional: true
-  checksum: 5b03bba2e5f9dde2044fd2fba920bda58fa3550c85dc4f69a9a9e796ac8d7d7e3583c4ad1f8ae449e602614870bc313590ecfdb87eb24eae577db0f573aba3e2
+  checksum: 4320c96a131c071ed38be64a43115a2ee0ce7ca028cd1861220fa11013f3c74e5e250405a6a108b338401335670b07ecdabcd0bcb93412278e43cb90c76c4a0f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,6 +4676,7 @@ __metadata:
     "@asteasolutions/zod-to-openapi": ^5.5.0
     "@dethcrypto/eth-sdk": ^0.3.4
     "@dethcrypto/eth-sdk-client": ^0.1.6
+    "@ethersproject/abi": ^5.7.0
     "@gnosis.pm/zodiac": ^3.3.2
     "@types/jest": ^29.5.2
     "@types/wait-on": ^5.3.1
@@ -4689,7 +4690,7 @@ __metadata:
     typescript: ^5.2.2
     wait-on: ^7.0.1
     zod: ^3.22.2
-    zodiac-roles-sdk: ^2.2.4
+    zodiac-roles-sdk: ^2.2.9
   languageName: unknown
   linkType: soft
 
@@ -13131,9 +13132,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zodiac-roles-sdk@npm:^2.2.4":
-  version: 2.2.4
-  resolution: "zodiac-roles-sdk@npm:2.2.4"
+"zodiac-roles-sdk@npm:^2.2.9":
+  version: 2.2.9
+  resolution: "zodiac-roles-sdk@npm:2.2.9"
   dependencies:
     ethers: ^5.4.7
     type-fest: ^3.7.1
@@ -13143,7 +13144,7 @@ __metadata:
   peerDependenciesMeta:
     "@dethcrypto/eth-sdk-client":
       optional: true
-  checksum: 3543610e583711b367977866a5b13af81732c79724f3a4a32a0944fcc1255e5b35797bad4f353033d07e0a6320eda0c8c2dcd896865bebbc4bc0b2abe0230240
+  checksum: c3a25712e954beb06a5848c0b698ca7c713a42c71dd49ebb9fb6285f8006ad50cf88e28967640a47ec0a937bb6be4fdc5552941a8310e4a4d66d721af6886973
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes use of the new Zodiac Roles annotation concept:

- Permissions are annotated by `uri` and `schema`
- GET request to `uri` is expected to return an array of permissions in scope of the annotation 
- GET request to `schema` is expected to return an OpenAPI description of the abstracted/annotated permission set, so we can render generic abstracted UIs for editing the permission set in the Roles app